### PR TITLE
Include tagged release version in docker image tag.

### DIFF
--- a/atlas/templates/Makefile.common.gotmpl
+++ b/atlas/templates/Makefile.common.gotmpl
@@ -7,8 +7,8 @@ DOCKERFILE_PATH		?= $(CURDIR)/docker
 
 # configuration for image names
 USERNAME			?= $(USER)
-GIT_COMMIT			?= $(shell git describe --dirty=-unsupported --always || echo pre-commit)
-IMAGE_VERSION		?= $(USERNAME)-dev-$(GIT_COMMIT)
+GIT_COMMIT			?= $(shell git describe --dirty=-unsupported --always --tags || echo pre-commit)
+IMAGE_VERSION		?= $(GIT_COMMIT)-$(USERNAME)
 
 # configuration for server binary and image
 SERVER_BINARY 		?= $(BUILD_PATH)/server

--- a/atlas/templates/Makefile.vars.gotmpl
+++ b/atlas/templates/Makefile.vars.gotmpl
@@ -4,8 +4,8 @@ DOCKERFILE_PATH		:= $(CURDIR)/docker
 
 # configuration for image names
 USERNAME		:= $(USER)
-GIT_COMMIT		:= $(shell git describe --dirty=-unsupported --always || echo pre-commit)
-IMAGE_VERSION		?= $(USERNAME)-dev-$(GIT_COMMIT)
+GIT_COMMIT		:= $(shell git describe --dirty=-unsupported --always --tags || echo pre-commit)
+IMAGE_VERSION		?= $(GIT_COMMIT)-$(USERNAME)
 {{ if .Registry }}IMAGE_REGISTRY ?= {{ .Registry}}
 {{ end}}
 # configuration for server binary and image


### PR DESCRIPTION
We are using numbered releases now, but the generated makefile doesn't use these release version numbers in the docker image tag. e.g., atlas.customer.logs release v0.4.1 results in the docker image `infobloxcto/atlas.customer.logs-server:thayward-dev-0ce5df6`.

With this PR, the same version would build as `infobloxcto/atlas.customer.logs-server:v0.4.1-thayward`.