### PR TITLE
change defaultInternalHealth from /health to /healthz

### DIFF
--- a/atlas/config.gotmpl
+++ b/atlas/config.gotmpl
@@ -57,7 +57,7 @@ const (
 	defaultInternalEnable    = false
 	defaultInternalAddress   = "0.0.0.0"
 	defaultInternalPort      = "8081"
-	defaultInternalHealth    = "/health"
+	defaultInternalHealth    = "/healthz"
 	defaultInternalReadiness = "/ready"
 
 	defaultConfigDirectory = "deploy/"


### PR DESCRIPTION
its referenced in deployment file as `healthz`. To make it consistent changing the default to `healthz`

#29 