### PR TITLE
Fixed bug that caused `make protobuf` to break if expand and gateway both used

### DIFF
--- a/atlas/templates/Makefile.common.gotmpl
+++ b/atlas/templates/Makefile.common.gotmpl
@@ -40,13 +40,11 @@ ifeq ($(WITH_DATABASE), true)
 PROTOBUF_ARGS += --gorm_out=.
 endif
 
-ifeq ($(WITH_EXPAND), true)
-PROTOBUF_ARGS += --grpc-gateway_out=logtostderr=true:.
-endif
-
 ifeq ($(WITH_GATEWAY), true)
 PROTOBUF_ARGS += --grpc-gateway_out="logtostderr=true,allow_delete_body=true:."
 PROTOBUF_ARGS += --swagger_out="atlas_patch=true,allow_delete_body=true:."
+else ifeq ($(WITH_EXPAND), true)
+PROTOBUF_ARGS += --grpc-gateway_out=logtostderr=true:.
 endif
 
 .PHONY all: all-atlas


### PR DESCRIPTION
using both options caused multiple `--grpc-gateway_out` options to be set