### PR TITLE
Add helm lint to e2e tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,5 +18,6 @@
 
 # bindata is not checked in
 atlas/templates/template-bindata.go
+atlas/test
 .bindata
 .vscode

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,19 @@ services:
 go:
   - "1.13.x"
 
-install: true
+env:
+  global:
+    - HELM_VERSION="v2.14.3"
+    - PATH="/tmp:$PATH"
+
+install:
+  - wget http://storage.googleapis.com/kubernetes-helm/helm-${HELM_VERSION}-linux-amd64.tar.gz -O /tmp/helm.tar.gz
+  - tar xzf /tmp/helm.tar.gz -C /tmp --strip-components=1
+  - chmod +x /tmp/helm
+
+before_script:
+  - /tmp/helm init --client-only
 
 script:
   - go mod init
-  - make templating test-with-integration
+  - make test-with-integration

--- a/Makefile
+++ b/Makefile
@@ -15,5 +15,5 @@ templating: .bindata
 test:
 	@go test -v ./...
 
-test-with-integration:
+test-with-integration: templating
 	@export e2e=true && go test -v ./...

--- a/atlas/main_test.go
+++ b/atlas/main_test.go
@@ -34,7 +34,7 @@ func TestMain(m *testing.M) {
 		log.Fatalf("failed to install atlas cli: %v", err)
 	}
 	log.Print("running init-app")
-	if out, err := exec.Command("atlas", "init-app", "-name=test", "-gateway", "-health", "-pubsub", "-debug").CombinedOutput(); err != nil {
+	if out, err := exec.Command("atlas", "init-app", "-name=test", "-gateway", "-health", "-helm", "-pubsub", "-debug").CombinedOutput(); err != nil {
 		log.Print(string(out))
 		log.Fatalf("failed to run atlas init-app: %v", err)
 	}
@@ -91,5 +91,14 @@ func TestFormatting(t *testing.T) {
 		// print unformatted files on a single line, not multiple lines
 		files := strings.Split(string(out), "\n")
 		t.Fatalf("test application has unformatted go code: %v", strings.Join(files, " "))
+	}
+}
+
+func TestHelmLint(t *testing.T) {
+	cmd := exec.Command("helm", "lint", "helm/test")
+	cmd.Dir = "./test"
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("helm lint failed: %v\n%s", err, string(out))
 	}
 }

--- a/atlas/templates/helm/templates/deployment.yaml.gotmpl
+++ b/atlas/templates/helm/templates/deployment.yaml.gotmpl
@@ -39,7 +39,7 @@ spec:
             - name: POSTGRES_SSLMODE
               value: {{ "{{" }} .Values.db.sslMode {{ "}}" }}
             - name: POSTGRES_HOST
-              value: "{{ "{{" }} tpl (.Values.db.server) . {{ "}}" }}"
+              value: "{{ "{{" }} tpl (.Values.db.server | required "must set db.server") . {{ "}}" }}"
             - name: POSTGRES_PORT
               value: {{ "{{" }} .Values.db.port | quote {{ "}}" }}
             - name: POSTGRES_DB

--- a/atlas/templates/helm/templates/migrations.yaml.gotmpl
+++ b/atlas/templates/helm/templates/migrations.yaml.gotmpl
@@ -35,7 +35,7 @@ spec:
       - name: POSTGRES_DB
         value: {{ "{{" }} tpl .Values.db.database . {{ "}}" }}
       - name: POSTGRES_HOST
-        value: {{ "{{" }} tpl .Values.db.server . {{ "}}" }}
+        value: {{ "{{" }} tpl (.Values.db.server | required "must set db.server") . {{ "}}" }}
       - name: POSTGRES_PORT
         value: {{ "{{" }} .Values.db.port | quote {{ "}}" }}
       - name: POSTGRES_SSLMODE

--- a/atlas/templates/helm/templates/secrets.yaml.gotmpl
+++ b/atlas/templates/helm/templates/secrets.yaml.gotmpl
@@ -1,5 +1,5 @@
+{{- if .WithDatabase }}
 {{ "{{" }} if .Values.secrets.enabled -{{ "}}" }}
-{{ if .WithDatabase }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -7,7 +7,7 @@ metadata:
     namespace: {{ "{{" }} .Release.Namespace {{ "}}" }}
 type: Opaque
 data:
-    password: {{ "{{" }} .Values.db.password | b64enc {{ "}}" }}
+    password: {{ "{{" }} .Values.db.password | required "must set db.password or disable secrets" | b64enc {{ "}}" }}
 ---
-{{ end }}
 {{ "{{" }} end {{ "}}" }}
+{{- end }}

--- a/atlas/templates/helm/values.yaml.gotmpl
+++ b/atlas/templates/helm/values.yaml.gotmpl
@@ -57,7 +57,7 @@ tolerations: []
 
 affinity: {}
 
-{{ if .WithDatabase }}
+{{- if .WithDatabase }}
 postgres:
   enabled: true
 migration:
@@ -71,7 +71,10 @@ db:
   database: {{ .Helm.GetName }}
   sslMode: disable
   port: "5432"
-{{ end }}
+
+secrets:
+  enabled: true
+{{- end }}
 
 app:
   serviceName: {{ .Helm.GetName }}


### PR DESCRIPTION
I set out to add `helm lint` to the e2e tests and encountered a bunch issues with the e2e tests along the way. There is one commit to fix each of them in this PR. You might want to review each commit separately.