### PR TITLE
Use vendored code

### DIFF
--- a/atlas/templates/Makefile.common.gotmpl
+++ b/atlas/templates/Makefile.common.gotmpl
@@ -23,6 +23,7 @@ DOCKER_GENERATOR        ?= infoblox/atlas-gentool:latest
 GENERATOR               ?= $(DOCKER_RUNNER) $(DOCKER_GENERATOR)
 
 # configuration for building on host machine
+export GOFLAGS          ?= -mod=vendor
 GO_CACHE                ?= -pkgdir $(BUILD_PATH)/go-cache
 GO_BUILD_FLAGS          ?= $(GO_CACHE) -i -v
 GO_TEST_FLAGS           ?= -v -cover

--- a/atlas/templates/docker/Dockerfile.gotmpl
+++ b/atlas/templates/docker/Dockerfile.gotmpl
@@ -4,7 +4,7 @@ LABEL stage=server-intermediate
 WORKDIR /go/src/{{ .Root }}/{{ .Name }}
 
 COPY . .
-RUN go build -o bin/server ./cmd/server
+RUN go build -mod=vendor -o bin/server ./cmd/server
 
 # copy the server binary from builder stage; run the server binary
 FROM alpine:latest AS runner


### PR DESCRIPTION
The makefile template provides a `make vendor` target to populate the `vendor` directory with modules, but the `go build` and `go test` stages were not actually using the vendored code. This PR sets the flag to use the vendored code instead of downloading it again.