### PR TITLE
allow running PR test manually

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -2,6 +2,11 @@ name: PR
 on:
   pull_request:
   workflow_dispatch:
+    inputs:
+      make-flags:
+        description: additional flags to supply to make
+        required: false
+        default: DOCKER_GENERATOR=infoblox/atlas-gentool:latest
 jobs:
   test:
     name: Test with integration
@@ -38,4 +43,4 @@ jobs:
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config --global user.name "github-actions[bot]"
 
-          make test-with-integration
+          make test-with-integration ${{ github.event.inputs.make-flags }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,5 +1,7 @@
 name: PR
-on: pull_request
+on:
+  pull_request:
+  workflow_dispatch:
 jobs:
   test:
     name: Test with integration


### PR DESCRIPTION
This will allow us to run the PR test manually on any branch from the UI, in case we want to manually test with a specific version of atlas-gentool.