### PR TITLE
fix: perform Jenkins cleanup in cleanup block

### DIFF
--- a/atlas/templates/Jenkinsfile.gotmpl
+++ b/atlas/templates/Jenkinsfile.gotmpl
@@ -44,8 +44,8 @@ pipeline {
     }{{end}}
   }
   post {
-    always {
-        sh "make clean || true"
+    cleanup {
+      sh "make clean || true"
       cleanWs()
     }
   }


### PR DESCRIPTION
Jenkins specifies that cleanup should be done in the `cleanup` block:
https://www.jenkins.io/doc/book/pipeline/syntax/#post

Previously, `atlas-cli` was generating a Jenkinsfile that did cleanup in the `always` block. This can be problematic when there are multiple `post` conditions. `always` is always the first post-condition to run. If `always` cleans up the artifacts before `success` has a chance to process them, the pipeline will fail. By appropriately using the `cleanup` block, the cleanup will run after all other operations.