### PR TITLE
Added docker permissions check before running protoc

### DIFF
--- a/atlas/commands/bootstrap/bootstrap.go
+++ b/atlas/commands/bootstrap/bootstrap.go
@@ -113,6 +113,10 @@ func (b Bootstrap) Run() error {
 		}
 	}
 
+	if err := checkDockerPermissions(); err != nil {
+		return err
+	}
+
 	if err := generateProtobuf(); err != nil {
 		return err
 	}
@@ -144,6 +148,16 @@ func runCommand(command string, args ...string) error {
 	}
 	if err := cmd.Run(); err != nil {
 		return err
+	}
+	return nil
+}
+
+// check that docker have enough permissions
+func checkDockerPermissions() error {
+	cmd := exec.Command("docker", "info")
+	if output, err := cmd.Output(); err != nil {
+		output := string(output)
+		return errors.New(output[strings.Index(output, "ERROR:"):])
 	}
 	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,6 @@ module github.com/infobloxopen/atlas-cli
 go 1.14
 
 require (
-	github.com/go-bindata/go-bindata v3.1.2+incompatible // indirect
-	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/iancoleman/strcase v0.0.0-20180726023541-3605ed457bf7
 	github.com/jinzhu/inflection v1.0.0
 	golang.org/x/tools v0.0.0-20200528185414-6be401e3f76e

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,3 @@
-github.com/go-bindata/go-bindata v3.1.2+incompatible/go.mod h1:xK8Dsgwmeed+BBsSy2XTopBn/8uK2HWuGSnA11C3Joo=
-github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
-github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
-github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/iancoleman/strcase v0.0.0-20180726023541-3605ed457bf7 h1:ux/56T2xqZO/3cP1I2F86qpeoYPCOzk+KF/UH/Ar+lk=
 github.com/iancoleman/strcase v0.0.0-20180726023541-3605ed457bf7/go.mod h1:SK73tn/9oHe+/Y0h39VT4UCxmurVJkR5NA7kMEAOgSE=
 github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD/E=
@@ -26,5 +22,3 @@ golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
-google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=


### PR DESCRIPTION
When you trying to run atlas-cli on a clean machine without setting up docker correctly, you see just log `Generating protobuf ... exit status 2`. That's not good, because it's a very common issue, so I propose to check `docker info` before any actions.