### PR TITLE
Fix gorm.proto path for template

### DIFF
--- a/atlas/templates/pkg/pb/service.proto.gotmpl
+++ b/atlas/templates/pkg/pb/service.proto.gotmpl
@@ -6,7 +6,7 @@ import "google/protobuf/empty.proto";
 import "google/api/annotations.proto";
 import "github.com/envoyproxy/protoc-gen-validate/validate/validate.proto";
 import "protoc-gen-openapiv2/options/annotations.proto";{{ if or .ExpandName .WithDatabase }}
-import "github.com/infobloxopen/protoc-gen-gorm/options/gorm.proto";{{ end }}
+import "github.com/infobloxopen/protoc-gen-gorm/proto/options/gorm.proto";{{ end }}
 {{ if .ExpandName }}
 import "google/protobuf/field_mask.proto";
 //import "github.com/infobloxopen/protoc-gen-gorm/types/types.proto";


### PR DESCRIPTION
There was a relocation of a file in https://github.com/infobloxopen/protoc-gen-gorm (commit: 736bb0f9cf46b9222c48fca87f8d41b6bcda2965) that broke generation using -db flag.