### PR TITLE
Fix ingress template

### DIFF
--- a/atlas/templates/helm/templates/database.yaml.gotmpl
+++ b/atlas/templates/helm/templates/database.yaml.gotmpl
@@ -39,14 +39,14 @@ spec:
           image: "{{ "{{" }} .Values.postgres.image {{ "}}" }}:{{ "{{" }} .Values.postgres.version {{ "}}" }}"
           env:
             - name: POSTGRES_USER
-            value: {{ "{{" }} .Values.db.username {{ "}}" }}
+              value: {{ "{{" }} .Values.db.username {{ "}}" }}
             - name: POSTGRES_PASSWORD
-            valueFrom:
-              secretKeyRef:
-              name: {{ "{{" }}  include "chart.fullname" . {{ "}}" }}-db-key
-              key: password
+              valueFrom:
+                secretKeyRef:
+                name: {{ "{{" }}  include "chart.fullname" . {{ "}}" }}-db-key
+                key: password
             - name: POSTGRES_DB
-            value: {{ "{{" }} .Values.db.database {{ "}}" }}
+              value: {{ "{{" }} .Values.db.database {{ "}}" }}
           ports:
             - containerPort: {{ "{{" }} .Values.postgres.port {{ "}}" }}
           livenessProbe:

--- a/atlas/templates/helm/templates/ingress.yaml.gotmpl
+++ b/atlas/templates/helm/templates/ingress.yaml.gotmpl
@@ -33,9 +33,12 @@ spec:
         paths:
         {{ "{{" }}- range .paths {{ "}}" }}
           - path: {{ "{{" }} .path {{ "}}" }}
+            pathType: Prefix
             backend:
-              serviceName: {{ "{{" }} tpl .name $ {{ "}}" }}
-              servicePort: {{ "{{" }} tpl .port $ {{ "}}" }}
+              service:
+                name: {{ "{{" }} tpl .name $ {{ "}}" }}
+                port:
+                  number: {{ "{{" }} tpl .port $ {{ "}}" }}
         {{ "{{" }}- end {{ "}}" }}
   {{ "{{" }}- end {{ "}}" }}
 {{ "{{" }}- end {{ "}}" }}


### PR DESCRIPTION
When apiversion for Ingress has been changed from v1beta1 to v1, we are facing the same issue as [described here](https://stackoverflow.com/questions/64125048/get-error-unknown-field-servicename-in-io-k8s-api-networking-v1-ingressbacken). This PR fixes that issue.