### PR TITLE
remove musl hack

### DIFF
--- a/atlas/templates/docker/Dockerfile.debug.gotmpl
+++ b/atlas/templates/docker/Dockerfile.debug.gotmpl
@@ -15,10 +15,6 @@ RUN CGO_ENABLED=0 GOOS=linux go build -gcflags="all=-N -l" -o bin/server ./cmd/s
 FROM alpine:latest AS runner
 WORKDIR /bin
 
-# Go programs require libc
-RUN mkdir -p /lib64 && \
-    ln -s /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2
-
 COPY --from=builder /go/src/{{ .Root }}/{{ .Name }}/bin/server .
 {{ if .WithGateway }}COPY pkg/pb/*.swagger.json www/swagger.json{{ end }}
 {{ if .WithDatabase }}COPY --from=builder /go/src/{{ .Root }}/{{ .Name }}/db/migrations /db/migrations/{{end}}

--- a/atlas/templates/docker/Dockerfile.gotmpl
+++ b/atlas/templates/docker/Dockerfile.gotmpl
@@ -1,5 +1,5 @@
 # build the server binary
-FROM golang:1.19 AS builder
+FROM golang:1.19-alpine AS builder
 LABEL stage=server-intermediate
 WORKDIR /go/src/{{ .Root }}/{{ .Name }}
 
@@ -9,10 +9,6 @@ RUN go build -mod=vendor -o bin/server ./cmd/server
 # copy the server binary from builder stage; run the server binary
 FROM alpine:latest AS runner
 WORKDIR /bin
-
-# Go programs require libc
-RUN mkdir -p /lib64 && \
-    ln -s /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2
 
 COPY --from=builder /go/src/{{ .Root }}/{{ .Name }}/bin/server .
 {{ if .WithGateway }}COPY pkg/pb/*.swagger.json www/swagger.json{{ end }}


### PR DESCRIPTION
No manual linking is needed for libc when the builder distro matches the runner distro.